### PR TITLE
(Sprint 1) Tests para hooks `pre-commit` y `commit-msg`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 text.txt
-text.txt
+
+# Entorno 
+.venv/
+
+# Cache de pytest
+__pycache__/
+.pytest_cache

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install-deps install-hooks setup
+.PHONY: install-deps install-hooks setup test
 
 install-deps:
 	@echo "Instalando black (Python formatter)..."
@@ -21,3 +21,6 @@ install-hooks:
 
 setup: install-deps install-hooks
 	@echo "Setup completo. ya puede usar git commit"
+
+test:
+	pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+addopts = -vv .
+testpaths = tests
+pythonpath = .
+markers =
+    critical: test crítico

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,14 +28,14 @@ def temp_repo(tmp_path, monkeypatch):
         hooks_dir = git_dir / "hooks"
         hooks_dir.mkdir(exist_ok=True)
         project_root = Path(__file__).resolve().parents[1]
-        src_hook = project_root / "src" / "pre-commit"
+        src_hook = project_root / "scripts" / "pre-commit"
         if src_hook.exists():
             dest_hook = hooks_dir / "pre-commit"
             shutil.copy2(src_hook, dest_hook)
             os.chmod(dest_hook, 0o755)
         
         # Instalar el hook commit-msg en .git/hooks/commit-msg del repositorio temporal
-        src_commit_msg = project_root / "src" / "commit-msg"
+        src_commit_msg = project_root / "scripts" / "commit-msg"
         if src_commit_msg.exists():
             dest_commit_msg = hooks_dir / "commit-msg"
             shutil.copy2(src_commit_msg, dest_commit_msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import os
+import subprocess
+import pytest
+from pathlib import Path
+import shutil
+
+# Fixture para repositorio temporal
+@pytest.fixture
+def temp_repo(tmp_path, monkeypatch):
+    # Crear repositorio temporal
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    # Monkeypatch GIT_DIR
+    git_dir = repo / ".git"
+    monkeypatch.setenv("GIT_DIR", str(git_dir))
+
+    cwd = os.getcwd()
+    os.chdir(repo)
+    try:
+        # Configuración minima del repositorio temporal
+        subprocess.run(["git", "init"], check=True)
+        subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
+        subprocess.run(["git", "config", "user.name", "Test User"], check=True)
+        
+        # Instalar el hook pre-commit en .git/hooks/pre-commit del repositorio temporal
+        # para que git lo ejecute automáticamente durante 'git commit'
+        hooks_dir = git_dir / "hooks"
+        hooks_dir.mkdir(exist_ok=True)
+        project_root = Path(__file__).resolve().parents[1]
+        src_hook = project_root / "src" / "pre-commit"
+        if src_hook.exists():
+            dest_hook = hooks_dir / "pre-commit"
+            shutil.copy2(src_hook, dest_hook)
+            os.chmod(dest_hook, 0o755)
+        
+        # Instalar el hook commit-msg en .git/hooks/commit-msg del repositorio temporal
+        src_commit_msg = project_root / "src" / "commit-msg"
+        if src_commit_msg.exists():
+            dest_commit_msg = hooks_dir / "commit-msg"
+            shutil.copy2(src_commit_msg, dest_commit_msg)
+            os.chmod(dest_commit_msg, 0o755)
+    except Exception:
+        # git no disponible en este entorno; continuar sin inicializar
+        pass
+    yield repo
+    os.chdir(cwd)

--- a/tests/test_commit_msg.py
+++ b/tests/test_commit_msg.py
@@ -1,0 +1,48 @@
+import subprocess
+import pytest
+from pathlib import Path
+import os
+
+@pytest.fixture(autouse=True)
+def remove_pre_commit_hook(temp_repo):
+    """
+    Fxiture para borrar el hook pre-commit antes de cada test (depende temp_repo para GIT_DIR)
+    """
+    git_dir = Path(os.getenv("GIT_DIR"))
+    pre_commit_hook = git_dir / "hooks" / "pre-commit"
+    
+    # Borrar el hook si existe
+    if pre_commit_hook.exists():
+        pre_commit_hook.unlink()
+    
+    yield
+
+@pytest.mark.parametrize("message", [
+    "feat(ejemplo): mensaje correcto",
+    "fix(ejemplo): good msg",
+    "test(ejemplo): buen mensaje"
+])
+def test_commit_msg_valid(temp_repo, message):
+    # Crear un archivo para commitear
+    (temp_repo / "README.md").write_text("Contenido válido")
+
+    subprocess.run(["git", "add", "."])
+    result = subprocess.run(["git", "commit", "-m", message], capture_output=True, text=True)
+
+    assert result.returncode == 0
+    assert "correcto" in result.stdout.lower() or "correcto" in result.stderr.lower()
+
+@pytest.mark.parametrize("message", [
+    "mal mensaje",
+    "BaD meSsage",
+    "hola(ejemplo): no es buen mensaje"
+])
+def test_commit_msg_invalid(temp_repo, message):
+    # Crear un archivo para commitear
+    (temp_repo / "README.md").write_text("Contenido válido")
+
+    subprocess.run(["git", "add", "."])
+    result = subprocess.run(["git", "commit", "-m", message], capture_output=True, text=True)
+
+    assert result.returncode == 1
+    assert "error" in result.stdout.lower() or "error" in result.stderr.lower()

--- a/tests/test_pre_commit.py
+++ b/tests/test_pre_commit.py
@@ -1,0 +1,96 @@
+import subprocess
+import pytest
+from pathlib import Path
+import os
+import shutil
+
+def _command_exists(cmd):
+    """Helper para verificar si un comando está disponible."""
+    return shutil.which(cmd) is not None
+
+@pytest.fixture(autouse=True)
+def remove_commit_msg_hook(temp_repo):
+    """Borra el hook pre-commit antes de cada test (depende de temp_repo para GIT_DIR)."""
+    git_dir = Path(os.getenv("GIT_DIR"))
+    pre_commit_hook = git_dir / "hooks" / "commit-msg"
+    
+    # Borrar el hook si existe
+    if pre_commit_hook.exists():
+        pre_commit_hook.unlink()
+    
+    yield
+
+@pytest.mark.skipif(not _command_exists("black"), reason="black no está instalado")
+def test_pre_commit_invalid_format (temp_repo):
+    # Crear script de python con error de formato (indentacion invalida)
+    (temp_repo / "example.py").write_text("  import os")
+
+    subprocess.run(["git", "add", "."])
+    result = subprocess.run(["git", "commit", "-m", "ejemplo"], capture_output=True, text=True)
+    
+    print (result)
+
+    assert result.returncode == 1
+    assert "formato incorrecto" in result.stdout.lower() or result.stderr.lower()
+
+@pytest.mark.skipif(not _command_exists("black"), reason="black no está instalado")
+def test_pre_commit_valid_format (temp_repo):
+    # Crear script de python con formato valido
+    (temp_repo / "example.py").write_text(
+        'def suma(a, b):\n'
+        '    return a + b\n'
+        '\n'
+        '\n'
+        'print(suma(1, 2))\n'
+    )
+
+    subprocess.run(["git", "add", "."])
+    result = subprocess.run(["git", "commit", "-m", "ejemplo"], capture_output=True, text=True)
+    
+    print (result)
+
+    assert result.returncode == 0
+    assert "All done!" in result.stdout.lower() or result.stderr.lower()
+
+@pytest.mark.skipif(not _command_exists("gitleaks"), reason="gitleaks no está instalado")
+def test_pre_commit_pass_no_secrets(temp_repo):
+    # Crear un archivo sin secretos
+    (temp_repo / "safe_file.txt").write_text("Este es un contenido seguro.")
+    
+    subprocess.run(["git", "add", "."])
+    result = subprocess.run(["git", "commit", "-m", "ejemplo"], capture_output=True, text=True)
+    
+    print (result)
+
+    assert result.returncode == 0
+    assert "no leaks found" in result.stdout.lower() or result.stderr.lower()
+
+@pytest.mark.skipif(not _command_exists("gitleaks"), reason="gitleaks no está instalado")
+def test_pre_commit_fail_with_secrets(temp_repo):
+    # Crear un archivo con un secreto que gitleaks pueda detectar
+    # Usamos un formato comun para claves de AWS
+    (temp_repo / "credentials.env").write_text("AWS_ACCESS_KEY_ID = AKIAJVWFRSSWQP3A7EXA")
+    
+    subprocess.run(["git", "add", "."])
+    result = subprocess.run(["git", "commit", "-m", "ejemplo"], capture_output=True, text=True)
+    
+    print (result)
+
+    assert result.returncode == 1
+    assert "leaks found: " in result.stdout.lower() or result.stderr.lower()
+
+def test_pre_commit_detects_large_file(temp_repo):
+    # Crear archivo lo suficientemente grande para que el hook detecte
+    large_file = temp_repo / "large_file"
+    with open(large_file, "wb") as f:
+        f.seek(11 * 1024 * 1024)  # 11MB
+        f.write(b'\0')
+
+    subprocess.run(["git", "add", "."])
+    result = subprocess.run(["git", "commit", "-m", "ejemplo"], capture_output=True, text=True)
+
+    print (result)
+    
+    assert result.returncode == 1
+    assert "archivos >10mb" in result.stdout.lower() or result.stderr.lower()
+    assert "large_file" in result.stdout.lower () or result.stderr.lower()


### PR DESCRIPTION
## Cambios realizados
- `test_pre_commit.py`: Tests para el hook de pre-commit
  - El fixture que usa, crea un repositorio temporal, cambia la variable de entorno `GIT_DIR` y copia el hook ahí.
  - Se implementan tests específicos para `black`, `gitleaks` y el tamaño de archivos.
  - Se omiten tests si es que no se encuentra alguna de esas herramientas instaladas
- `test_commit_msg.py`: Test para el hook de commit-msg
  - El fixture que usa, crea un repositorio temporal, cambia la variable de entorno `GIT_DIR` y copia el hook ahí.
  - Se implementan los tests para el hook que verifica que el commit tiene un mensaje de acuerdo a los _conventional commits_
- `pytest.ini`: Configuración de pytest
- `Makefile`: Target `test` para ejecutar la suite de pruebas

## Checklist

**Vinculación y formato**
- [x] Commits siguen [Conventional Commits](https://www.conventionalcommits.org)
- [x] PR vinculado al issue: `Fixes #6 `
- [x] Título claro y descriptivo

**Calidad y pruebas**
- [x] Lint y tests verdes (`pytest -vv --cov`)
- [x] Cobertura ≥85%
- [x] No se introducen secretos (.env, claves, tokens)

**Impacto en tablero**
- [x] Tarjeta movida a `In Progress`

## Políticas de Seguridad

| Categoría | Política | Cumple |
|------------|-----------|--------|
| **Puertos** | Ningún puerto adicional abierto sin aprobación del equipo | [x] |
| **Secretos** | Ningún secreto expuesto en código, PR o .env | [x] |
| **Licencias** | Solo dependencias con licencia compatible (MIT, Apache-2.0, BSD) | [x] |
| **Tamaño de artefactos** | No subir binarios >10 MB al repo | [x] |
| **Revisión cruzada** | ≥1 aprobación (≥2 si módulo sensible) | [] |
| **Conformidad CI** | CI verde (lint, tests, cobertura, secretos, IaC) | [x] |


