### PR TITLE
(Sprint 2) Linting y formateo de tests en python con black

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,13 @@ setup: install-deps install-hooks
 	@echo "Setup completo. ya puede usar git commit"
 
 test:
+	@echo "Ejecutando tests..."
 	pytest
+
+format:
+	@echo "Formateando código python con black..."
+	@black tests
+
+format-check:
+	@echo "Verificando formato (sin modificar archivos)..."
+	@black --check tests --diff

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from pathlib import Path
 import shutil
 
+
 # Fixture para repositorio temporal
 @pytest.fixture
 def temp_repo(tmp_path, monkeypatch):
@@ -22,7 +23,7 @@ def temp_repo(tmp_path, monkeypatch):
         subprocess.run(["git", "init"], check=True)
         subprocess.run(["git", "config", "user.email", "test@example.com"], check=True)
         subprocess.run(["git", "config", "user.name", "Test User"], check=True)
-        
+
         # Instalar el hook pre-commit en .git/hooks/pre-commit del repositorio temporal
         # para que git lo ejecute automáticamente durante 'git commit'
         hooks_dir = git_dir / "hooks"
@@ -33,7 +34,7 @@ def temp_repo(tmp_path, monkeypatch):
             dest_hook = hooks_dir / "pre-commit"
             shutil.copy2(src_hook, dest_hook)
             os.chmod(dest_hook, 0o755)
-        
+
         # Instalar el hook commit-msg en .git/hooks/commit-msg del repositorio temporal
         src_commit_msg = project_root / "scripts" / "commit-msg"
         if src_commit_msg.exists():

--- a/tests/test_commit_msg.py
+++ b/tests/test_commit_msg.py
@@ -3,6 +3,7 @@ import pytest
 from pathlib import Path
 import os
 
+
 @pytest.fixture(autouse=True)
 def remove_pre_commit_hook(temp_repo):
     """
@@ -10,39 +11,46 @@ def remove_pre_commit_hook(temp_repo):
     """
     git_dir = Path(os.getenv("GIT_DIR"))
     pre_commit_hook = git_dir / "hooks" / "pre-commit"
-    
+
     # Borrar el hook si existe
     if pre_commit_hook.exists():
         pre_commit_hook.unlink()
-    
+
     yield
 
-@pytest.mark.parametrize("message", [
-    "feat(ejemplo): mensaje correcto",
-    "fix(ejemplo): good msg",
-    "test(ejemplo): buen mensaje"
-])
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "feat(ejemplo): mensaje correcto",
+        "fix(ejemplo): good msg",
+        "test(ejemplo): buen mensaje",
+    ],
+)
 def test_commit_msg_valid(temp_repo, message):
     # Crear un archivo para commitear
     (temp_repo / "README.md").write_text("Contenido válido")
 
     subprocess.run(["git", "add", "."])
-    result = subprocess.run(["git", "commit", "-m", message], capture_output=True, text=True)
+    result = subprocess.run(
+        ["git", "commit", "-m", message], capture_output=True, text=True
+    )
 
     assert result.returncode == 0
     assert "correcto" in result.stdout.lower() or "correcto" in result.stderr.lower()
 
-@pytest.mark.parametrize("message", [
-    "mal mensaje",
-    "BaD meSsage",
-    "hola(ejemplo): no es buen mensaje"
-])
+
+@pytest.mark.parametrize(
+    "message", ["mal mensaje", "BaD meSsage", "hola(ejemplo): no es buen mensaje"]
+)
 def test_commit_msg_invalid(temp_repo, message):
     # Crear un archivo para commitear
     (temp_repo / "README.md").write_text("Contenido válido")
 
     subprocess.run(["git", "add", "."])
-    result = subprocess.run(["git", "commit", "-m", message], capture_output=True, text=True)
+    result = subprocess.run(
+        ["git", "commit", "-m", message], capture_output=True, text=True
+    )
 
     assert result.returncode == 1
     assert "error" in result.stdout.lower() or "error" in result.stderr.lower()

--- a/tests/test_pre_commit.py
+++ b/tests/test_pre_commit.py
@@ -4,93 +4,112 @@ from pathlib import Path
 import os
 import shutil
 
+
 def _command_exists(cmd):
     """Helper para verificar si un comando está disponible."""
     return shutil.which(cmd) is not None
+
 
 @pytest.fixture(autouse=True)
 def remove_commit_msg_hook(temp_repo):
     """Borra el hook pre-commit antes de cada test (depende de temp_repo para GIT_DIR)."""
     git_dir = Path(os.getenv("GIT_DIR"))
     pre_commit_hook = git_dir / "hooks" / "commit-msg"
-    
+
     # Borrar el hook si existe
     if pre_commit_hook.exists():
         pre_commit_hook.unlink()
-    
+
     yield
 
+
 @pytest.mark.skipif(not _command_exists("black"), reason="black no está instalado")
-def test_pre_commit_invalid_format (temp_repo):
+def test_pre_commit_invalid_format(temp_repo):
     # Crear script de python con error de formato (indentacion invalida)
     (temp_repo / "example.py").write_text("  import os")
 
     subprocess.run(["git", "add", "."])
-    result = subprocess.run(["git", "commit", "-m", "ejemplo"], capture_output=True, text=True)
-    
-    print (result)
+    result = subprocess.run(
+        ["git", "commit", "-m", "ejemplo"], capture_output=True, text=True
+    )
+
+    print(result)
 
     assert result.returncode == 1
     assert "formato incorrecto" in result.stdout.lower() or result.stderr.lower()
 
+
 @pytest.mark.skipif(not _command_exists("black"), reason="black no está instalado")
-def test_pre_commit_valid_format (temp_repo):
+def test_pre_commit_valid_format(temp_repo):
     # Crear script de python con formato valido
     (temp_repo / "example.py").write_text(
-        'def suma(a, b):\n'
-        '    return a + b\n'
-        '\n'
-        '\n'
-        'print(suma(1, 2))\n'
+        "def suma(a, b):\n" "    return a + b\n" "\n" "\n" "print(suma(1, 2))\n"
     )
 
     subprocess.run(["git", "add", "."])
-    result = subprocess.run(["git", "commit", "-m", "ejemplo"], capture_output=True, text=True)
-    
-    print (result)
+    result = subprocess.run(
+        ["git", "commit", "-m", "ejemplo"], capture_output=True, text=True
+    )
+
+    print(result)
 
     assert result.returncode == 0
     assert "All done!" in result.stdout.lower() or result.stderr.lower()
 
-@pytest.mark.skipif(not _command_exists("gitleaks"), reason="gitleaks no está instalado")
+
+@pytest.mark.skipif(
+    not _command_exists("gitleaks"), reason="gitleaks no está instalado"
+)
 def test_pre_commit_pass_no_secrets(temp_repo):
     # Crear un archivo sin secretos
     (temp_repo / "safe_file.txt").write_text("Este es un contenido seguro.")
-    
+
     subprocess.run(["git", "add", "."])
-    result = subprocess.run(["git", "commit", "-m", "ejemplo"], capture_output=True, text=True)
-    
-    print (result)
+    result = subprocess.run(
+        ["git", "commit", "-m", "ejemplo"], capture_output=True, text=True
+    )
+
+    print(result)
 
     assert result.returncode == 0
     assert "no leaks found" in result.stdout.lower() or result.stderr.lower()
 
-@pytest.mark.skipif(not _command_exists("gitleaks"), reason="gitleaks no está instalado")
+
+@pytest.mark.skipif(
+    not _command_exists("gitleaks"), reason="gitleaks no está instalado"
+)
 def test_pre_commit_fail_with_secrets(temp_repo):
     # Crear un archivo con un secreto que gitleaks pueda detectar
     # Usamos un formato comun para claves de AWS
-    (temp_repo / "credentials.env").write_text("AWS_ACCESS_KEY_ID = AKIAJVWFRSSWQP3A7EXA")
-    
+    (temp_repo / "credentials.env").write_text(
+        "AWS_ACCESS_KEY_ID = AKIAJVWFRSSWQP3A7EXA"
+    )
+
     subprocess.run(["git", "add", "."])
-    result = subprocess.run(["git", "commit", "-m", "ejemplo"], capture_output=True, text=True)
-    
-    print (result)
+    result = subprocess.run(
+        ["git", "commit", "-m", "ejemplo"], capture_output=True, text=True
+    )
+
+    print(result)
 
     assert result.returncode == 1
     assert "leaks found: " in result.stdout.lower() or result.stderr.lower()
+
 
 def test_pre_commit_detects_large_file(temp_repo):
     # Crear archivo lo suficientemente grande para que el hook detecte
     large_file = temp_repo / "large_file"
     with open(large_file, "wb") as f:
         f.seek(11 * 1024 * 1024)  # 11MB
-        f.write(b'\0')
+        f.write(b"\0")
 
     subprocess.run(["git", "add", "."])
-    result = subprocess.run(["git", "commit", "-m", "ejemplo"], capture_output=True, text=True)
+    result = subprocess.run(
+        ["git", "commit", "-m", "ejemplo"], capture_output=True, text=True
+    )
 
-    print (result)
-    
+    print(result)
+
     assert result.returncode == 1
     assert "archivos >10mb" in result.stdout.lower() or result.stderr.lower()
-    assert "large_file" in result.stdout.lower () or result.stderr.lower()
+    assert "large_file" in result.stdout.lower() or result.stderr.lower()


### PR DESCRIPTION
## Cambios realizados
- `Makefile`: Nuevos targets para manejar tareas de formato
- Se ejecutó `make format` para formatear automáticamente el código de los tests de los hooks.

## Checklist

**Vinculación y formato**
- [x] Commits siguen [Conventional Commits](https://www.conventionalcommits.org)
- [x] PR vinculado al issue: `Fixes #20`
- [x] Título claro y descriptivo

**Calidad y pruebas**
- [x] No se introducen secretos (.env, claves, tokens)

**Impacto en tablero**
- [x] Tarjeta movida a `In progress`

## Políticas de Seguridad

| Categoría | Política | Cumple |
|------------|-----------|--------|
| **Puertos** | Ningún puerto adicional abierto sin aprobación del equipo | [x] |
| **Secretos** | Ningún secreto expuesto en código, PR o .env | [x] |
| **Licencias** | Solo dependencias con licencia compatible (MIT, Apache-2.0, BSD) | [x] |
| **Tamaño de artefactos** | No subir binarios >10 MB al repo | [x] |
| **Revisión cruzada** | ≥1 aprobación (≥2 si módulo sensible) | [x] |


